### PR TITLE
Inject namespace into chart urls (#84)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.14 as builder
 
 WORKDIR /workspace
 COPY main.go main.go

--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,13 @@ IMG ?= multiclusterhub-repo
 VERSION ?= latest
 
 image:
-	./cicd-scripts/build.sh "$(REGISTRY)/$(IMG):$(VERSION)"
+	docker build -t "$(REGISTRY)/$(IMG):$(VERSION)" .
 
 push:
-	./scripts/push.sh "$(REGISTRY)/$(IMG):$(VERSION)"
+	docker push "$(REGISTRY)/$(IMG):$(VERSION)"
 
 unit-test:
-	./cicd-scripts/unit-test.sh
+	go test -v
 
 # local builds a docker image and runs it locally
 local:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/open-cluster-management/multicloudhub-repo
 
-go 1.13
+go 1.14

--- a/main.go
+++ b/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -11,29 +14,47 @@ import (
 	"time"
 )
 
-const (
-	// chartsDir is the directory that holds all charts to serve
-	chartDir = "./multiclusterhub/charts/"
-	// gracePeriod is the duration for which the server will gracefully wait for existing connections to finish
-	gracePeriod = time.Second * 15
-	// port the server listens on
-	port = ":3000"
+var (
+	chartDir    = "./multiclusterhub/charts/"
+	ns          = os.Getenv("POD_NAMESPACE")
+	port        = "3000"
+	serviceName = "multiclusterhub-repo"
 )
+
+// Server holds an index.yaml
+type Server struct {
+	Index []byte
+}
 
 func main() {
 	log.Printf("Go Version: %s", runtime.Version())
 	log.Printf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
 
+	// Hold index file in memory
+	index, err := readIndex()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Modify urls in index to reference namespace deployed in
+	if ns != "" {
+		log.Printf("Updating index with namespace '%s'", ns)
+		index = modifyIndex(index, ns)
+	}
+
+	s := &Server{Index: index}
+
 	mux := http.NewServeMux()
 
 	// Add route handlers
 	fileServer := http.FileServer(http.Dir(chartDir))
-	mux.Handle("/liveness", loggingMiddleware(http.HandlerFunc(livenessHandler)))
-	mux.Handle("/readiness", loggingMiddleware(http.HandlerFunc(readinessHandler)))
+	mux.Handle("/liveness", http.HandlerFunc(livenessHandler))
+	mux.Handle("/readiness", http.HandlerFunc(readinessHandler))
+	mux.Handle("/charts/index.yaml", http.HandlerFunc(s.indexHandler))
 	mux.Handle("/charts/", loggingMiddleware(http.StripPrefix("/charts/", fileServer)))
 
 	srv := &http.Server{
-		Addr: port,
+		Addr: ":" + port,
 		// Good practice to set timeouts to avoid Slowloris attacks.
 		WriteTimeout: time.Second * 30,
 		ReadTimeout:  time.Second * 30,
@@ -54,11 +75,11 @@ func main() {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	// Block until we receive our signal.
-	<-sigs
-	log.Println("Shutdown signal received")
+	sig := <-sigs
+	log.Printf("Received signal: %s", sig.String())
 
 	// Create a deadline to wait for.
-	ctx, cancel := context.WithTimeout(context.Background(), gracePeriod)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	// Doesn't block if no connections, but will otherwise wait
 	// until the timeout deadline.
@@ -91,6 +112,30 @@ func loggingMiddleware(next http.Handler) http.Handler {
 
 		log.Printf("%d %3dms %s", crw.status, duration.Milliseconds(), r.RequestURI)
 	})
+}
+
+func readIndex() ([]byte, error) {
+	f, err := ioutil.ReadFile(chartDir + "index.yaml")
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// modifyIndex makes urls namespace-specific
+func modifyIndex(index []byte, ns string) []byte {
+	oldURL := []byte(serviceName)
+	newURL := []byte(fmt.Sprintf("%s.%s", serviceName, ns))
+
+	newIndex := bytes.ReplaceAll(index, oldURL, newURL)
+	return newIndex
+}
+
+// indexHandler serves the index.yaml file from in memory
+func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := w.Write(s.Index); err != nil {
+		log.Println(err)
+	}
 }
 
 // livenessHandler returns a 200 status as long as the server is running


### PR DESCRIPTION
* Read POD_NAMESPACE and update chart urls
Update to Go 1.14
Serve index from memory

* reduce log spam

* log any error serving index.yaml

Co-authored-by: Jakob Gray <jakobgray@ibm.com>