### PR TITLE
Add more complete url for dns resolution

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -90,7 +90,7 @@ func indexURL(c *config.Config) string {
 	if c.Namespace == "" {
 		return fmt.Sprintf("http://%s:%s/charts", c.Service, c.Port)
 	}
-	return fmt.Sprintf("http://%s.%s:%s/charts", c.Service, c.Namespace, c.Port)
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%s/charts", c.Service, c.Namespace, c.Port)
 }
 
 // indexHandler serves the index.yaml file from in memory

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -113,7 +113,7 @@ func Test_indexURL(t *testing.T) {
 					Port:      "8000",
 					Service:   "multicloudhub-repo",
 				}},
-			want: "http://multicloudhub-repo.test:8000/charts",
+			want: "http://multicloudhub-repo.test.svc.cluster.local:8000/charts",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
BZ issue: https://bugzilla.redhat.com/show_bug.cgi?id=1853485
Github Issue: open-cluster-management/backlog#3284

A user could not reach the helm repo channel because of a proxy. Adding the ".cluster.local" suffix might help other users with proxy rules so the the local request doesn't get routed through the proxy.