### PR TITLE
Give Openshift user access to charts directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,6 @@ COPY --from=builder /workspace/start-repo .
 COPY multiclusterhub/charts/ multiclusterhub/charts/
 EXPOSE 3000
 ENTRYPOINT /app/start-repo
+
+RUN chgrp -R 0 /app && \
+    chmod -R g=u /app


### PR DESCRIPTION
I was having problems with `make patch-charts-in-cluster`. The commands got various "permission denied" errors. This seemed to resolve the issue - it gives the root group read/write access to the app directory (the container user in OpenShift is always a member of that group).

See https://docs.openshift.com/container-platform/4.7/openshift_images/create-images.html#use-uid_create-images