### PR TITLE
Change the TLS support from 1.3 back to 1.2 to resolve fips CVE

### DIFF
--- a/multiclusterhub/charts/grc/templates/grc-policy-propagator-deployment.yaml
+++ b/multiclusterhub/charts/grc/templates/grc-policy-propagator-deployment.yaml
@@ -85,7 +85,7 @@ spec:
         - --v=6
         - "--tls-cert-file=/var/run/policy-metrics-cert/tls.crt"
         - "--tls-private-key-file=/var/run/policy-metrics-cert/tls.key"
-        - "--tls-min-version=VersionTLS13"
+        - "--tls-min-version=VersionTLS12"
         ports:
         - containerPort: 8443
           name: https


### PR DESCRIPTION
To address and OCP FIPS CVE we need to make sure TLS 1.2 is the min TLS

Refs:
 - https://access.redhat.com/security/vulnerabilities/RHSB-2023-001